### PR TITLE
standard install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,27 +11,20 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python >=3.8
+    - setuptools >=42
+    - setuptools-scm >=3.4
     - pip
-    - setuptools_scm
   run:
-    - dask-core
     - python >=3.8
-    - zarr >=2.11
+    - dask-core
     - mypy_extensions
-    - dask
-    # dask[array]
-    - numpy >=1.21
-    # dask[diagnostics]
-    - bokeh >=2.4.2, <3
-    - jinja2 >=2.10.3
-    # extras but not all of the complete!?
-    - xarray >=2022.3
+    - zarr >=2.11
 
 test:
   imports:


### PR DESCRIPTION
@rsignell-usgs this may disrupt folks that are relying on the behavior of a "batteries incuded" rechunker. However, keep the extras updated is quite problematic as you are noticing on your workflow. I'd rather if we ship only the minimum required dependencies here for now.